### PR TITLE
feat: add image message support for Feishu bridge

### DIFF
--- a/internal/clawdbot/client.go
+++ b/internal/clawdbot/client.go
@@ -27,6 +27,13 @@ func NewClient(port int, token, agentID string) *Client {
 	}
 }
 
+// Attachment represents a file attachment (e.g., image)
+// Format: { mimeType: "image/png", content: "<base64>" }
+type Attachment struct {
+	MimeType string `json:"mimeType"`  // e.g., "image/png"
+	Content  string `json:"content"`   // base64 encoded data
+}
+
 // Request represents a request to the gateway
 type Request struct {
 	Type   string      `json:"type"`
@@ -77,11 +84,12 @@ type AuthInfo struct {
 
 // AgentParams contains agent request parameters
 type AgentParams struct {
-	Message        string `json:"message"`
-	AgentID        string `json:"agentId"`
-	SessionKey     string `json:"sessionKey"`
-	Deliver        bool   `json:"deliver"`
-	IdempotencyKey string `json:"idempotencyKey"`
+	Message        string        `json:"message"`
+	AgentID        string        `json:"agentId"`
+	SessionKey     string        `json:"sessionKey"`
+	Deliver        bool          `json:"deliver"`
+	IdempotencyKey string        `json:"idempotencyKey"`
+	Attachments    []*Attachment `json:"attachments,omitempty"`
 }
 
 // AgentPayload contains the agent response payload
@@ -98,14 +106,19 @@ type EventPayload struct {
 
 // StreamData contains stream data
 type StreamData struct {
-	Text  string `json:"text,omitempty"`
-	Delta string `json:"delta,omitempty"`
-	Phase string `json:"phase,omitempty"`
+	Text    string `json:"text,omitempty"`
+	Delta   string `json:"delta,omitempty"`
+	Phase   string `json:"phase,omitempty"`
 	Message string `json:"message,omitempty"`
 }
 
 // AskClawdbot sends a message to ClawdBot and returns the response
 func (c *Client) AskClawdbot(text, sessionKey string) (string, error) {
+	return c.AskClawdbotWithAttachments(text, sessionKey, nil)
+}
+
+// AskClawdbotWithAttachments sends a message with attachments to ClawdBot
+func (c *Client) AskClawdbotWithAttachments(text, sessionKey string, attachments []*Attachment) (string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -188,6 +201,7 @@ func (c *Client) AskClawdbot(text, sessionKey string) (string, error) {
 						SessionKey:     sessionKey,
 						Deliver:        false,
 						IdempotencyKey: uuid.New().String(),
+						Attachments:    attachments,
 					},
 				}
 


### PR DESCRIPTION
## Summary
This PR adds support for image messages in the Feishu bridge.

## Changes

### internal/feishu/client.go
- Add `MsgType`, `ImageKey`, and `ImageData` fields to Message struct
- Handle both text and image message types
- Implement `DownloadImage` method using Feishu MessageResource API
- Add `GetImageBase64` helper function

### internal/clawdbot/client.go  
- Add `Attachment` struct for file attachments (mimeType + base64 content)
- Add `Attachments` field to `AgentParams`
- Implement `AskClawdbotWithAttachments` method
- Refactor `AskClawdbot` to use the new method internally

### internal/bridge/bridge.go
- Update `HandleMessage` to process image messages
- Convert image data to base64 and create attachments
- Always respond to image messages in group chats
- Rename `processMessage` to `processMessageWithAttachments`

## Testing
- Tested with Feishu image messages in both direct and group chats
- Images are successfully downloaded and passed to Clawdbot for processing
- Text messages continue to work as expected