### PR TITLE
feat: add allowlist support for users and chats

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -183,7 +183,7 @@ func cmdRun() {
 		cfg.Clawdbot.AgentID,
 	)
 
-	bridgeInstance := bridge.NewBridge(nil, clawdbotClient, cfg.Feishu.ThinkingThresholdMs)
+	bridgeInstance := bridge.NewBridge(nil, clawdbotClient, cfg.Feishu.ThinkingThresholdMs, cfg.Feishu.AllowUsers, cfg.Feishu.AllowChats)
 
 	feishuClient := feishu.NewClient(
 		cfg.Feishu.AppID,

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -17,6 +17,8 @@ type Bridge struct {
 	feishuClient   *feishu.Client
 	clawdbotClient *clawdbot.Client
 	thinkingMs     int
+	allowUsers     map[string]bool
+	allowChats     map[string]bool
 	seenMessages   *messageCache
 }
 
@@ -71,11 +73,21 @@ func (mc *messageCache) cleanup() {
 }
 
 // NewBridge creates a new bridge
-func NewBridge(feishuClient *feishu.Client, clawdbotClient *clawdbot.Client, thinkingMs int) *Bridge {
+func NewBridge(feishuClient *feishu.Client, clawdbotClient *clawdbot.Client, thinkingMs int, allowUsers, allowChats []string) *Bridge {
+	au := make(map[string]bool, len(allowUsers))
+	for _, u := range allowUsers {
+		au[u] = true
+	}
+	ac := make(map[string]bool, len(allowChats))
+	for _, c := range allowChats {
+		ac[c] = true
+	}
 	return &Bridge{
 		feishuClient:   feishuClient,
 		clawdbotClient: clawdbotClient,
 		thinkingMs:     thinkingMs,
+		allowUsers:     au,
+		allowChats:     ac,
 		seenMessages:   newMessageCache(10 * time.Minute),
 	}
 }
@@ -96,6 +108,12 @@ func (b *Bridge) HandleMessage(msg *feishu.Message) error {
 	// Mark as seen
 	if msg.MessageID != "" {
 		b.seenMessages.add(msg.MessageID)
+	}
+
+	// Check allowlist
+	if !b.isAllowed(msg) {
+		log.Printf("[Bridge] Blocked message from user=%s chat=%s (not in allowlist)", msg.SenderID, msg.ChatID)
+		return nil
 	}
 
 	// Clean up message text
@@ -207,6 +225,28 @@ func (b *Bridge) processMessage(chatID, text string) {
 			log.Printf("[Bridge] Sent message to %s", chatID)
 		}
 	}
+}
+
+// isAllowed checks if the message passes the allowlist filter.
+// If no allowlist is configured (both empty), all messages are allowed.
+// If allow_users is set, the sender's open_id must be listed.
+// If allow_chats is set, the chat_id must be listed.
+// If both are set, either match is sufficient.
+func (b *Bridge) isAllowed(msg *feishu.Message) bool {
+	// No allowlist configured = allow all
+	if len(b.allowUsers) == 0 && len(b.allowChats) == 0 {
+		return true
+	}
+
+	if len(b.allowChats) > 0 && b.allowChats[msg.ChatID] {
+		return true
+	}
+
+	if len(b.allowUsers) > 0 && b.allowUsers[msg.SenderID] {
+		return true
+	}
+
+	return false
 }
 
 // shouldRespondInGroup determines if the bot should respond in a group chat

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,8 @@ type FeishuConfig struct {
 	AppID               string
 	AppSecret           string
 	ThinkingThresholdMs int
+	AllowUsers          []string
+	AllowChats          []string
 }
 
 // ClawdbotConfig contains Clawdbot Gateway configuration
@@ -43,8 +45,10 @@ type bridgeJSON struct {
 		AppID     string `json:"app_id"`
 		AppSecret string `json:"app_secret"`
 	} `json:"feishu"`
-	ThinkingThresholdMs *int   `json:"thinking_threshold_ms,omitempty"`
-	AgentID             string `json:"agent_id"`
+	ThinkingThresholdMs *int     `json:"thinking_threshold_ms,omitempty"`
+	AgentID             string   `json:"agent_id"`
+	AllowUsers          []string `json:"allow_users,omitempty"`
+	AllowChats          []string `json:"allow_chats,omitempty"`
 }
 
 // Dir returns the config directory path
@@ -144,6 +148,13 @@ func Load() (*Config, error) {
 			GatewayToken: gwCfg.Gateway.Auth.Token,
 			AgentID:      "main",
 		},
+	}
+
+	if len(brCfg.AllowUsers) > 0 {
+		cfg.Feishu.AllowUsers = brCfg.AllowUsers
+	}
+	if len(brCfg.AllowChats) > 0 {
+		cfg.Feishu.AllowChats = brCfg.AllowChats
 	}
 
 	if brCfg.ThinkingThresholdMs != nil {

--- a/internal/feishu/client.go
+++ b/internal/feishu/client.go
@@ -21,6 +21,7 @@ type Message struct {
 	MessageID   string
 	ChatID      string
 	ChatType    string
+	SenderID    string
 	Content     string
 	Mentions    []Mention
 }
@@ -94,11 +95,20 @@ func (c *Client) handleMessage(ctx context.Context, event *larkim.P2MessageRecei
 		return nil
 	}
 
+	// Extract sender ID
+	senderID := ""
+	if event.Event.Sender != nil && event.Event.Sender.SenderId != nil {
+		if event.Event.Sender.SenderId.OpenId != nil {
+			senderID = *event.Event.Sender.SenderId.OpenId
+		}
+	}
+
 	// Build message
 	message := &Message{
 		MessageID: getStringValue(msg.MessageId),
 		ChatID:    getStringValue(msg.ChatId),
 		ChatType:  getStringValue(msg.ChatType),
+		SenderID:  senderID,
 		Content:   content.Text,
 	}
 


### PR DESCRIPTION
Add `allow_users` and `allow_chats` fields to `bridge.json` config.

## Usage

```json
{
  "feishu": {
    "app_id": "cli_xxx",
    "app_secret": "xxx"
  },
  "allow_users": ["ou_xxxx"],
  "allow_chats": ["oc_xxxx"]
}
```

## Behavior

- **Both empty** (default): all messages allowed — fully backward compatible
- **`allow_users` set**: only messages from listed `open_id`s are processed
- **`allow_chats` set**: only messages from listed `chat_id`s are processed
- **Both set**: either match is sufficient (OR logic)
- Blocked messages are logged with sender/chat info for debugging

## Changes

- `internal/config/config.go`: added `AllowUsers` / `AllowChats` to config structs
- `internal/feishu/client.go`: extract `SenderID` (open_id) from event
- `internal/bridge/bridge.go`: `isAllowed()` check before processing; updated `NewBridge` signature
- `cmd/bridge/main.go`: pass allowlist to `NewBridge`