### PR TITLE
feat: 支持用户和群组白名单过滤

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -183,7 +183,7 @@ func cmdRun() {
 		cfg.Clawdbot.AgentID,
 	)
 
-	bridgeInstance := bridge.NewBridge(nil, clawdbotClient, cfg.Feishu.ThinkingThresholdMs)
+	bridgeInstance := bridge.NewBridge(nil, clawdbotClient, cfg.Feishu.ThinkingThresholdMs, cfg.Feishu.AllowUsers, cfg.Feishu.AllowChats)
 
 	feishuClient := feishu.NewClient(
 		cfg.Feishu.AppID,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,8 @@ type FeishuConfig struct {
 	AppID               string
 	AppSecret           string
 	ThinkingThresholdMs int
+	AllowUsers          []string
+	AllowChats          []string
 }
 
 // ClawdbotConfig contains Clawdbot Gateway configuration
@@ -43,8 +45,10 @@ type bridgeJSON struct {
 		AppID     string `json:"app_id"`
 		AppSecret string `json:"app_secret"`
 	} `json:"feishu"`
-	ThinkingThresholdMs *int   `json:"thinking_threshold_ms,omitempty"`
-	AgentID             string `json:"agent_id"`
+	ThinkingThresholdMs *int     `json:"thinking_threshold_ms,omitempty"`
+	AgentID             string   `json:"agent_id"`
+	AllowUsers          []string `json:"allow_users,omitempty"`
+	AllowChats          []string `json:"allow_chats,omitempty"`
 }
 
 // Dir returns the config directory path
@@ -144,6 +148,13 @@ func Load() (*Config, error) {
 			GatewayToken: gwCfg.Gateway.Auth.Token,
 			AgentID:      "main",
 		},
+	}
+
+	if len(brCfg.AllowUsers) > 0 {
+		cfg.Feishu.AllowUsers = brCfg.AllowUsers
+	}
+	if len(brCfg.AllowChats) > 0 {
+		cfg.Feishu.AllowChats = brCfg.AllowChats
 	}
 
 	if brCfg.ThinkingThresholdMs != nil {

--- a/internal/feishu/client.go
+++ b/internal/feishu/client.go
@@ -21,6 +21,7 @@ type Message struct {
 	MessageID   string
 	ChatID      string
 	ChatType    string
+	SenderID    string
 	Content     string
 	Mentions    []Mention
 }
@@ -94,11 +95,20 @@ func (c *Client) handleMessage(ctx context.Context, event *larkim.P2MessageRecei
 		return nil
 	}
 
+	// Extract sender ID
+	senderID := ""
+	if event.Event.Sender != nil && event.Event.Sender.SenderId != nil {
+		if event.Event.Sender.SenderId.OpenId != nil {
+			senderID = *event.Event.Sender.SenderId.OpenId
+		}
+	}
+
 	// Build message
 	message := &Message{
 		MessageID: getStringValue(msg.MessageId),
 		ChatID:    getStringValue(msg.ChatId),
 		ChatType:  getStringValue(msg.ChatType),
+		SenderID:  senderID,
 		Content:   content.Text,
 	}
 


### PR DESCRIPTION
在 `bridge.json` 中新增 `allow_users` 和 `allow_chats` 配置项，可限制哪些飞书用户（按 `open_id`）和群聊（按 `chat_id`）能与机器人交互。

**行为：**
- 两个列表都为空 → 接受所有消息（向后兼容）
- 任一列表有值 → 仅处理匹配的发送者/群聊，其余静默丢弃并记录日志

**配置示例：**
```json
{
  "feishu": { "app_id": "cli_xxx", "app_secret": "xxx" },
  "allow_users": ["ou_xxxxx"],
  "allow_chats": ["oc_xxxxx"]
}
```

**改动（4 个文件，+66/-5）：**
- `internal/config/config.go` — 从 bridge.json 解析 `allow_users`/`allow_chats`
- `internal/feishu/client.go` — 从消息事件中提取发送者 `open_id`
- `internal/bridge/bridge.go` — 新增 `isAllowed()` 白名单检查，日志中包含 user ID
- `cmd/bridge/main.go` — 将白名单配置传入 bridge 构造函数